### PR TITLE
Feature/post install patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Simple patches plugin for Composer. Applies a patch from a local or remote file 
 Patching is enabled when:
 
 * project has "patches" key defined under "extra" 
-* project has "enable-patching" key defined under "extra" (use this one if there are no patches directly defined for the project)
-* 
+* project has "enable-patching" key defined under "extra" 
+
+_Note that the latter is only useful if you have no patches defined directly on the root level_
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ Please note that in both cases the patch path should be relative to the context 
 * For project, it should be relative to project root
 * For package, it should be relative to package root 
 
+## Alternative format
+
+In case it's important to retain the patching order, one can also use alternative declaration format that uses array wrapper:
+
+```
+{
+  "extra": {
+    "patches": {
+      "targeted/package": [
+        {
+          "label": "desription about my patch", 
+          "url": "my/file.patch"
+        }
+      ]
+    }
+  }
+}
+
+```
+
+
 ## Using patch url
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Simple patches plugin for Composer. Applies a patch from a local or remote file to any package required with composer.
 
+## Enabling patching for a project
+
+Patching is enabled when:
+
+* project has "patches" key defined under "extra" 
+* project has "enable-patching" key defined under "extra" (use this one if there are no patches directly defined for the project)
+* 
+
+```
+{
+  "extra": {
+    "patches": {},
+    "enable-patching": true
+  }
+}
+
+```
+
 ## Usage
 
 Example composer.json:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,36 @@ Instead of a patches key in your root composer.json, use a patches-file key.
 
 ```
 
-Then your composer.patches.json should look like this:
+## Using patch file
+
+Same format is used for both project (root level scope) patches and for package patches.
+
+```
+{
+  "require": {
+    "cweagans/composer-patches": "~1.0",
+    "drupal/drupal": "8.0.*@dev"
+  },
+  "config": {
+    "preferred-install": "source"
+  },
+  "extra": {
+    "patches": {
+      "targeted/package": {
+        "desription about my patch": "my/file.patch"
+      }
+    }
+  }
+}
+
+```
+
+Please note that in both cases the patch path should be relative to the context where it's defined:
+
+* For project, it should be relative to project root
+* For package, it should be relative to package root 
+
+## Using patch url
 
 ```
 {
@@ -58,8 +87,15 @@ Then your composer.patches.json should look like this:
 }
 ```
 
+## Hints on creating a patch 
+
+The file-paths in the patch should be relative to the targeted package root and start with ./
+
+This means that patch for a file <projet>/vendor/my/package/some/file.php whould be targeted in the patch as ./some/file.php
+
 ## Difference between this and netresearch/composer-patches-plugin
 
+* Works on project AND package level
 * This plugin is much more simple to use and maintain
 * This plugin doesn't require you to specify which package version you're patching
 * This plugin is easy to use with Drupal modules (which don't use semantic versioning).

--- a/README.md
+++ b/README.md
@@ -150,6 +150,41 @@ Patches can be stored in remote location and referred to by using the full URL o
 }
 ```
 
+## Excluding patch
+
+In case some patches that are defined in packages have to be excluded from the project (project has custom verisons of the files, conflicts with other patches, etc), patch exclusions can be defined.
+
+Package that owns the patch:
+
+```
+{
+  "name": "patch/owner",
+  "extra": {
+    "patches": {
+      "targeted/package": {
+        "desription about my patch": "path/to/file.patch"
+      }
+    }
+  }
+}
+
+```
+
+Project level:
+
+```
+{
+  "extra": {
+    "excluded-patches": {
+      "patch/owner": [
+        "path/to/file.patch"
+      ]
+    }
+  }
+}
+
+```
+
 ## Hints on creating a patch 
 
 The file-paths in the patch should be relative to the targeted package root and start with ./

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Patches can be stored in remote location and referred to by using the full URL o
 }
 ```
 
-## Excluding patch
+## Excluding patches
 
 In case some patches that are defined in packages have to be excluded from the project (project has custom verisons of the files, conflicts with other patches, etc), patch exclusions can be defined.
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "php": ">=5.3.0",
-    "composer-plugin-api": "~1.0"
+    "composer-plugin-api": "^1.0"
   },
   "require-dev": {
     "composer/composer": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "30f088b412bd90f3f7991f14f1718ec6",
-    "content-hash": "774194ddb99178b240d0c0eabc7c889e",
+    "hash": "a2cd6826c202b7ebefe3050efc2a7b7f",
+    "content-hash": "0ed9361502c0f5f22a5b440c16640193",
     "packages": [],
     "packages-dev": [
         {
@@ -18,7 +18,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/a54f84f05f915c6d42bed94de0cdcb4406a4707b",
+                "url": "https://api.github.com/repos/composer/composer/zipball/f2d606ae0c705907d8bfa1c6f884bced1255b827",
                 "reference": "a54f84f05f915c6d42bed94de0cdcb4406a4707b",
                 "shasum": ""
             },
@@ -153,7 +153,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/b2dbc76d1c3f81f33857cdd49c0be6ce7b87897d",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/022fc25ca664f612b1e7007e0d87642ef489f000",
                 "reference": "b2dbc76d1c3f81f33857cdd49c0be6ce7b87897d",
                 "shasum": ""
             },
@@ -383,7 +383,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4f9b1eaf0a7da77c362f8d91cbc68ab1f4718d62",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b02221e42163be673f9b44a0bc92a8b4907a7c6d",
                 "reference": "4f9b1eaf0a7da77c362f8d91cbc68ab1f4718d62",
                 "shasum": ""
             },
@@ -683,7 +683,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/be067d6105286b74272facefc2697038f8807b77",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/264188ddf4d3586c80ea615f8ec8eaea34e652a1",
                 "reference": "be067d6105286b74272facefc2697038f8807b77",
                 "shasum": ""
             },
@@ -875,7 +875,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/6899b3e33bfbd386d88b5eea5f65f563e8793051",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
                 "reference": "6899b3e33bfbd386d88b5eea5f65f563e8793051",
                 "shasum": ""
             },
@@ -927,7 +927,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
                 "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
                 "shasum": ""
             },
@@ -1095,7 +1095,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/7ff5b1b3dcc55b8ab8ae61ef99d4730940856ee7",
                 "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
                 "shasum": ""
             },
@@ -1183,7 +1183,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/fe114c7a6ac5cb0ce76932ae4017024d9842a49c",
+                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/b27db1514f7d7bb7a366ad95d4eb2b17140a0691",
                 "reference": "fe114c7a6ac5cb0ce76932ae4017024d9842a49c",
                 "shasum": ""
             },
@@ -1321,7 +1321,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/89a795226477f66745e8ea10415e769304114920",
+                "url": "https://api.github.com/repos/symfony/console/zipball/56cc5caf051189720b8de974e4746090aaa10d44",
                 "reference": "89a795226477f66745e8ea10415e769304114920",
                 "shasum": ""
             },
@@ -1377,7 +1377,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fc3fe52fef85e1f3e7775ffad92539e16c20e0af",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/65cb36b6539b1d446527d60457248f30d045464d",
                 "reference": "fc3fe52fef85e1f3e7775ffad92539e16c20e0af",
                 "shasum": ""
             },
@@ -1423,7 +1423,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/dcd5aaba34ca332abb7f33ec554ebd4d829cb202",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/877bb4b16ea573cc8c024e9590888fcf7eb7e0f7",
                 "reference": "dcd5aaba34ca332abb7f33ec554ebd4d829cb202",
                 "shasum": ""
             },
@@ -1469,7 +1469,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4e1daf58b375ea7c506d525dc7801df1c9a6ebbd",
+                "url": "https://api.github.com/repos/symfony/process/zipball/7dedd5b60550f33dca16dd7e94ef8aca8b67bbfe",
                 "reference": "4e1daf58b375ea7c506d525dc7801df1c9a6ebbd",
                 "shasum": ""
             },
@@ -1515,7 +1515,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/8d32eb597b531eb915b4fee3dc582ade5ae1fe6a",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ab0314f7544d600ea7917f02cdad774358b81113",
                 "reference": "8d32eb597b531eb915b4fee3dc582ade5ae1fe6a",
                 "shasum": ""
             },

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -165,7 +165,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // won't hurt anything, so we'll just stash it there.
     $this->patches['_patchesGathered'] = TRUE;
   }
-  
+
   /**
    * Get the patches from root composer or external file
    * @return Patches
@@ -263,6 +263,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       }
       catch (\Exception $e) {
         $this->io->write('   <error>Could not apply patch! Skipping.</error>');
+        if (getenv('COMPOSER_EXIT_ON_PATCH_FAILURE')) {
+          throw new \Exception("Cannot apply patch $description ($url)!");
+        }
       }
     }
     $localPackage->setExtra($extra);

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -295,6 +295,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
             throw new \Exception("Cannot apply patch $description ($url)!");
           }
 
+          if ($this->io->isVerbose()) {
+            $this->io->write('<warning>' . $e->getMessage() . '</warning>');
+          }
         }
       }
 

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -92,10 +92,6 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     );
   }
 
-//if (!$this->isPatchingEnabled()) {
-//return;
-//}
-
   protected function preparePatchDefinitions($patches, $ownerPackage = null) {
     $_patches = array();
 
@@ -362,6 +358,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
    * @throws \Exception
    */
   public function postInstall(Event $event) {
+    if (!$this->isPatchingEnabled()) {
+      return;
+    }
+
     $installationManager = $this->composer->getInstallationManager();
     $packageRepository = $this->composer->getRepositoryManager()->getLocalRepository();
 
@@ -372,7 +372,6 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
     $allPatches = $this->getAllPatches();
 
-    // ,"vaimo/patches-magento": "~2.1.0.0"
     /**
      * Uninstall some things where patches have changed
      */
@@ -388,6 +387,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
       if (isset($extra['patches_applied'])) {
         $applied = $extra['patches_applied'];
+
+        if (!$applied) {
+          continue;
+        }
 
         if (!array_diff_key($applied, $patches) && !array_diff_key($patches, $applied)) {
           continue;

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -293,12 +293,13 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         }
         catch (\Exception $e) {
           $this->io->write('   <error>Could not apply patch! Skipping.</error>');
-          if (getenv('COMPOSER_EXIT_ON_PATCH_FAILURE')) {
-            throw new \Exception("Cannot apply patch $description ($url)!");
-          }
 
           if ($this->io->isVerbose()) {
-            $this->io->write('<warning>' . $e->getMessage() . '</warning>');
+            $this->io->write('<warning>' . trim($e->getMessage(), "\n ") . '</warning>');
+          }
+
+          if (getenv('COMPOSER_EXIT_ON_PATCH_FAILURE')) {
+            throw new \Exception("Cannot apply patch $description ($url)!");
           }
         }
       }

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -253,6 +253,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
   public function postInstall(Event $event) {
     $packageRepository = $this->composer->getRepositoryManager()->getLocalRepository();
 
+    $patchesApplied = false;
     foreach ($packageRepository->getPackages() as $package) {
       $package_name = $package->getName();
 
@@ -288,6 +289,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
           $this->getAndApplyPatch($downloader, $install_path, $url);
           $this->eventDispatcher->dispatch(NULL, new PatchEvent(PatchEvents::POST_PATCH_APPLY, $package, $url, $description));
           $extra['patches_applied'][$description] = $url;
+          $patchesApplied = true;
         }
         catch (\Exception $e) {
           $this->io->write('   <error>Could not apply patch! Skipping.</error>');
@@ -307,7 +309,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $this->writePatchReport($this->patches[$package_name], $install_path);
     }
 
-    $packageRepository->write();
+    if ($patchesApplied) {
+      $packageRepository->write();
+    }
   }
 
   /**

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -385,6 +385,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $patches = $allPatches[$packageName];
       $extra = $package->getExtra();
 
+      if (!isset($extra['patches_applied'])) {
+        continue;
+      }
+
       if (isset($extra['patches_applied'])) {
         $applied = $extra['patches_applied'];
 


### PR DESCRIPTION
**Background**

Currently the patches are applied right after package install which means that developer has no way to add patches via packages due to not being able to define reverse-dependencies to some packages to dictate installation order.

This means that we currently don't have a way to move away from project-level patch management to something more granular that would be easy to maintain in larger scale (so that we could push certain patches to every project).

This branch is addressing the issue by moving the "apply instantly" logic to the moment of "apply when every package is installed".

**Package patches**

Extra changes to allow packages to have proper paths that are relative to the package root.

Another thing changed is the logic on how the patches are stored as multiple modules might end up overwriting each-others patches just because they have same description. Flipped this around so that the thing that has to be unique is the vendor path which will guarantee that you never end up being unpleasantly surprised.

**Installation**
```
aja project add-module cweagans/composer-patches:dev-feature/post-install-patching
```
@kassner