### PR TITLE
Do not normalize paths for the root package

### DIFF
--- a/src/Patch/Collector.php
+++ b/src/Patch/Collector.php
@@ -54,9 +54,10 @@ class Collector
                     }
 
                     foreach ($patches as $patch) {
+                        $isRoot = $patchOwner instanceof \Composer\Package\RootPackage;
                         $patchList[$target][] = array_replace($patch, array(
                             \Vaimo\ComposerPatches\Patch\Definition::OWNER => $patchOwner->getName(),
-                            \Vaimo\ComposerPatches\Patch\Definition::OWNER_TYPE => $patchOwner->getType()
+                            \Vaimo\ComposerPatches\Patch\Definition::OWNER_IS_ROOT => $isRoot,
                         ));
                     }
                 }

--- a/src/Patch/Definition.php
+++ b/src/Patch/Definition.php
@@ -8,8 +8,8 @@ class Definition
     const LABEL = 'label';
     const DEPENDS = 'depends';
     const VERSION = 'version';
-    const OWNER_TYPE = 'owner_type';
     const OWNER = 'owner';
+    const OWNER_IS_ROOT = 'owner_is_root';
     const HASH = 'md5';
     const TARGETS = 'targets';
 }

--- a/src/Patch/Owner.php
+++ b/src/Patch/Owner.php
@@ -1,8 +1,0 @@
-<?php
-namespace Vaimo\ComposerPatches\Patch;
-
-class Owner
-{
-    const PROJECT = 'project';
-    const MODULE = 'module';
-}

--- a/src/Patch/PathNormalizer.php
+++ b/src/Patch/PathNormalizer.php
@@ -2,7 +2,6 @@
 namespace Vaimo\ComposerPatches\Patch;
 
 use Vaimo\ComposerPatches\Patch\Definition as PatchDefinition;
-use Vaimo\ComposerPatches\Patch\Owner as PatchOwner;
 
 class PathNormalizer
 {
@@ -24,7 +23,7 @@ class PathNormalizer
     {
         foreach ($patches as $targetPackage => &$packagePatches) {
             foreach ($packagePatches as &$patchData) {
-                if ($patchData[PatchDefinition::OWNER_TYPE] == PatchOwner::PROJECT) {
+                if ($patchData[PatchDefinition::OWNER_IS_ROOT]) {
                     continue;
                 }
 


### PR DESCRIPTION
3.5.0 has broken #5 by adding root package to packages list: https://github.com/vaimo/composer-patches/blob/07361d88fc185023dbd87f4458398e7862863bcc/src/Managers/RepositoryManager.php#L116

Config:
```json
"extra": {
    "patches": {
        "binsoul/net-mqtt": [
            {
                "label": "1",
                "url": "https://github.com/valga/net-mqtt/commit/bc604a2ed963dbc176bc9241d8cf308fc9553cac.patch"
            },
            {
                "label": "2",
                "url": "https://github.com/valga/net-mqtt/commit/d55320fb4f9fdfa6cf9e49ea194793aeed1123af.patch"
            },
            {
                "label": "3",
                "url": "https://github.com/valga/net-mqtt/commit/97e1777ce9d78018ab568ff7f6389c12f3108949.patch"
            }
        ]
    },
    "enable-patching": true,
    "enable-patching-from-packages": false
}
```

When the root package is not a project, normalizer erroneously appends root package name to all paths:
```
Processing patches configuration
  - Applying patches for binsoul/net-mqtt
    ~ valga/fbns-react/https://github.com/valga/net-mqtt/commit/bc604a2ed963dbc176bc9241d8cf308fc9553cac.patch
      1
   Could not apply patch! Skipping.
    ~ valga/fbns-react/https://github.com/valga/net-mqtt/commit/d55320fb4f9fdfa6cf9e49ea194793aeed1123af.patch
      2
   Could not apply patch! Skipping.
    ~ valga/fbns-react/https://github.com/valga/net-mqtt/commit/97e1777ce9d78018ab568ff7f6389c12f3108949.patch
      3
   Could not apply patch! Skipping.
```