### PR TITLE
enforce "POSIX" behaviour to prevent partially applied patches.

### DIFF
--- a/src/Config/Defaults.php
+++ b/src/Config/Defaults.php
@@ -28,8 +28,8 @@ class Defaults
                 ),
                 'PATCH' => array(
                     'bin' => 'which patch',
-                    'check' => '[[bin]] -p{{level}} --no-backup-if-mismatch --dry-run < {{file}}',
-                    'patch' => '[[bin]] -p{{level}} --no-backup-if-mismatch < {{file}}'
+                    'check' => '[[bin]] -t --posix -p{{level}} --no-backup-if-mismatch --dry-run < {{file}}',
+                    'patch' => '[[bin]] -t --posix -p{{level}} --no-backup-if-mismatch < {{file}}'
                 )
             ),
             Config::PATCHER_OPERATIONS => array(


### PR DESCRIPTION
That should cause patch operation failure with error code, instead of 
"Hmm...  Ignoring the trailing garbage." (actual message from CLI with --verbose flag)