### PR TITLE
Fixed Windows quoting

### DIFF
--- a/src/Config/Defaults.php
+++ b/src/Config/Defaults.php
@@ -32,7 +32,7 @@ class Defaults
                 'DEFAULT' => array(
                     'resolver' => array(
                         'default' => '< which',
-                        'windows' => '< where'
+                        'windows' => '< where /F'
                     )
                 ),
                 'GIT' => array(


### PR DESCRIPTION
added /F switch to where to add double quotes to windows commands

fixes: #41

```
λ where /?

WHERE [/R dir] [/Q] [/F] [/T] pattern...
...snip...
    /F       Displays the matched filename in double quotes.
```