### PR TITLE
Fix/tests on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/installations/**/modules
 test/installations/**/patches
 test/installations/**/patches.json
 test/dependencies/modules
+*.org

--- a/bin/analyse-dependencies
+++ b/bin/analyse-dependencies
@@ -194,7 +194,7 @@ is_production_dependency()
 
         version_mm=$(echo ${version}|cut -d'.' -f1-2)
 
-        sed -i 's|_VERSION_|'${version_mm}'|g' $(pwd)/phpcs.xml
+        sed -i.org 's|_VERSION_|'${version_mm}'|g' $(pwd)/phpcs.xml
         
         _line '=' 80
         _title "CHECK VIABILITY WITH" "PHP ${version_mm}" "code compatibility of required dependencies"

--- a/bin/bootstrap-test-env
+++ b/bin/bootstrap-test-env
@@ -8,11 +8,12 @@ COPYRIGHT
 mkdir test/modules/composer-patches 2>/dev/null
 
 if [ ! -L test/modules/composer-patches/src ] ; then
-    ln -s $(readlink -f src) test/modules/composer-patches/src 2>/dev/null
+    ln -s $(cd src &>/dev/null && pwd) test/modules/composer-patches/src 2>/dev/null
 fi
 
 cp composer.json test/modules/composer-patches 2>/dev/null
 
-sed -i 's|composer-patches"|composer-patches-local"|g' test/modules/composer-patches/composer.json
+sed -i.org 's|composer-patches"|composer-patches-local"|g' test/modules/composer-patches/composer.json
+rm test/modules/composer-patches/composer.json.org 2>/dev/null
 
 exit 0

--- a/bin/test
+++ b/bin/test
@@ -189,14 +189,6 @@ assert_patches() {
     return 1
 }
 
-_is_macosx() {
-    if [[ "${OSTYPE}" == "darwin"* ]]; then
-        return 0
-    fi
-
-    return 1
-}
-
 assert_scenario_output() {
     local scenario_root=${1}
     local output_file=${2}
@@ -208,8 +200,7 @@ assert_scenario_output() {
     fi
 
     cat ${output_file} \
-        |sed -E "s/[[:cntrl:]]\[[0-9]{1,3}m//g" \
-        |sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" \
+        |perl -pe 's/\e\[[0-9;]*m(?:\e\[K)?//g' \
         |grep -v "^\s\s\s\s[0-9]\+/[0-9]\+:" \
         |grep -v "^\s\s\s\sFinished:\ssuccess:\s" \
         |grep -v "^You are running composer with xdebug enabled" \

--- a/bin/test
+++ b/bin/test
@@ -415,12 +415,12 @@ fi
     package_root=$(pwd)
      
     cd ${package_root}/test &>/dev/null
-    
+
     sandbox_root=$(pwd)
-    
-    installations=$(ls installations -1)
-    scenarios=$(ls scenarios -1)
-    
+
+    installations=$(ls -1 installations)
+    scenarios=$(ls -1 scenarios)
+
     if [ "${PURGE}" == "1" ] ; then
         for installation in ${installations} ; do
             installation_root=$(get_installation_root ${installation})

--- a/bin/test
+++ b/bin/test
@@ -267,7 +267,7 @@ process_assertions() {
     return 0
 }
 
-function apply_patches() {   
+apply_patches() {
     local args=${1}
     local out_file=${2}
  
@@ -339,7 +339,7 @@ assertion_error() {
     _error "ASSERTION: ${before} => ${after}"        
 }
 
-function reset_packages() {
+reset_packages() {
     local installation_root=${1}
     local install_info_path="${installation_root}/vendor/composer/installed.json"
     

--- a/bin/test
+++ b/bin/test
@@ -189,6 +189,14 @@ assert_patches() {
     return 1
 }
 
+_is_macosx() {
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
 assert_scenario_output() {
     local scenario_root=${1}
     local output_file=${2}
@@ -198,10 +206,10 @@ assert_scenario_output() {
     if [ ! -f ${output_file} ] ; then
         return 0
     fi
- 
+
     cat ${output_file} \
-        |sed -r "s/[[:cntrl:]]\[[0-9]{1,3}m//g" \
-        |sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" \
+        |sed -E "s/[[:cntrl:]]\[[0-9]{1,3}m//g" \
+        |sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" \
         |grep -v "^\s\s\s\s[0-9]\+/[0-9]\+:" \
         |grep -v "^\s\s\s\sFinished:\ssuccess:\s" \
         |grep -v "^You are running composer with xdebug enabled" \
@@ -344,30 +352,31 @@ reset_packages() {
     local install_info_path="${installation_root}/vendor/composer/installed.json"
     
     local lock_path="${installation_root}/composer.lock"
-    
+
     if [ -f ${install_info_path} ] ; then
-        sudo sed -i 's|\(\s"name":\s"\)\(vaimo/composer-patches-target\)\(.*\)",|\1__\2\3",|g' \
+        sed -i.org 's|\(\s"name":\s"\)\(vaimo/composer-patches-target\)\(.*\)",|\1__\2\3",|g' \
             ${install_info_path}
+
+        rm ${install_info_path}.org
             
-            local php_script=$(cat <<EOF
-                if (file_exists('${lock_path}')) {
-                
-                    \$config = json_decode(file_get_contents('${lock_path}'), true);
+        local php_script=$(cat <<EOF
+            if (file_exists('${lock_path}')) {
+                \$config = json_decode(file_get_contents('${lock_path}'), true);
                     
-                    foreach (['packages', 'packages-dev'] as \$group) {
-                        \$names = array_column(\$config[\$group], 'name');                    
-                        \$matches = preg_grep('|vaimo/composer-patches-target|', \$names);
+                foreach (['packages', 'packages-dev'] as \$group) {
+                    \$names = array_column(\$config[\$group], 'name');
+                    \$matches = preg_grep('|vaimo/composer-patches-target|', \$names);
                         
-                        foreach (array_keys(\$matches) as \$index) {
-                            \$config[\$group][\$index]['extra']['patches_applied'] = [];
-                        }  
+                    foreach (array_keys(\$matches) as \$index) {
+                        \$config[\$group][\$index]['extra']['patches_applied'] = [];
                     }
-                
-                    file_put_contents('${lock_path}', json_encode(\$config, JSON_PRETTY_PRINT));                
                 }
+                
+                file_put_contents('${lock_path}', json_encode(\$config, JSON_PRETTY_PRINT));
+            }
 EOF
 )            
-        
+
         php -r "${php_script}"        
     fi
     
@@ -448,17 +457,17 @@ fi
         
         (
             cd ${installation_root}
-        
+
             sanitize
 
             ln -s ${sandbox_root}/modules ${installation_root}
-            
+
             if [ ! -f composer.lock ] ; then
                 composer install --ansi --no-plugins
             else
                 composer install --ansi --no-plugins &>/dev/null
             fi
-    
+
             for scenario in ${scenarios} ; do
                 if [ "${scenarios_skip}" != "" ] && echo "${scenarios_skip}"|grep -q "^${scenario}$" ; then
                     continue
@@ -467,11 +476,11 @@ fi
                 if ! echo ${scenario}|grep -q "${scenario_filter}" ; then
                     continue
                 fi
-            
+
                 reset_packages "${installation_root}"
 
                 scenario_root=${sandbox_root}/scenarios/${scenario}
-                        
+
                 if ! run_tests "${scenario_root}" ; then
                     sanitize
                     
@@ -486,7 +495,7 @@ fi
             echo ''
         
             sanitize
-            
+
             exit 0
         )
         

--- a/bin/test
+++ b/bin/test
@@ -189,11 +189,25 @@ assert_patches() {
     return 1
 }
 
+_is_macosx() {
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
 assert_scenario_output() {
     local scenario_root=${1}
     local output_file=${2}
     
     local expected_output_file="${scenario_root}/.output"
+
+    if _is_macosx ; then
+        if [ -f ${expected_output_file}-darwin ] ; then
+            expected_output_file="${expected_output_file}-darwin"
+        fi
+    fi
  
     if [ ! -f ${output_file} ] ; then
         return 0

--- a/bin/test
+++ b/bin/test
@@ -9,7 +9,6 @@ script_root=$(dirname $(test -L ${script_path} && readlink -f ${script_path} || 
 
 source ${script_root}/lib/output.sh
 
-
 run_tests() {
     local scenario_root=${1}
         
@@ -359,7 +358,7 @@ reset_packages() {
     local lock_path="${installation_root}/composer.lock"
 
     if [ -f ${install_info_path} ] ; then
-        sed -i.org 's|\(\s"name":\s"\)\(vaimo/composer-patches-target\)\(.*\)",|\1__\2\3",|g' \
+        perl -i.org -pe 's|(\s"name":\s")(vaimo/composer-patches-target)(.*)",|\1__\2\3",|g' \
             ${install_info_path}
 
         rm ${install_info_path}.org

--- a/changelog.json
+++ b/changelog.json
@@ -4,6 +4,12 @@
         "possible to generate change-logs in other formats as well (when needed) and to do automatic releases based on",
         "added change-log records. More on how to use it: https://github.com/vaimo/composer-changelogs"
     ],
+    "DEV-3.51.3": {
+        "maintenance": [
+            "make it possible to run tests while developing the module on MacOS"
+        ],
+        "branch": "release/3"
+    },
     "3.51.2": {
         "fix": [
             "some errors not properly reported in the 'most likely' errors brief report (for patches with corrupt content)",

--- a/test/scenarios/apply-failure-corrupt-content/.output-darwin
+++ b/test/scenarios/apply-failure-corrupt-content/.output-darwin
@@ -1,0 +1,11 @@
+Processing patches configuration
+  - Applying patches for vaimo/composer-patches-target1 (1)
+    ~ vaimo/composer-patches-sandbox: patches/single-package-single-file-no-version.patch [NEW]
+      Change: value8 => valueC
+      Failed to apply the patch. Halting execution!
+      Probable causes for the failure:                                    
+                                                                          
+      > PATCH                                                             
+        ! can't find file to patch at input line 7                        
+                                                                          
+      (For full, unfiltered details please use: composer patch:apply -vvv)

--- a/test/scenarios/content-change/.commands
+++ b/test/scenarios/content-change/.commands
@@ -1,4 +1,4 @@
 patch:validate
 patch:apply
->sed -i 's/\+valueX/+valueZ/' patches/1_second-change.patch
+>sed -i.org 's/\+valueX/+valueZ/' patches/1_second-change.patch
 patch:apply

--- a/test/scenarios/rename/.commands
+++ b/test/scenarios/rename/.commands
@@ -1,5 +1,5 @@
 patch:validate
 patch:apply
 >mv patches/1_second-change.patch patches/1_renamed-patch.patch
->sed -i 's/valueX/valueZ/' patches/1_renamed-patch.patch
+>sed -i.org 's/valueX/valueZ/' patches/1_renamed-patch.patch
 patch:apply


### PR DESCRIPTION
# Motivation

Although this does not solve the underlying problem of using custom test runner that does not work for Windows, it does move closer to at least being able to run the tests on wider selection of systems.

# Description

Make it possible to run the test scenarios while working on the module directly on Mac OS. Previously the test were only executing properly on Linux.
