### PR TITLE
patches-searches path containing .patch fails

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -59,7 +59,7 @@ class Config
     const PATCHER_ARG_FILE = 'file';
     const PATCHER_ARG_CWD = 'cwd';
 
-    const PATCH_FILE_REGEX_MATCHER = '/^.+\.patch/i';
+    const PATCH_FILE_REGEX_MATCHER = '/^.+\.patch[^\/\\\\]*$/i';
 
     const PATCHER_FROM_SOURCE = 'from-source';
     const PATCHER_FORCE_REAPPLY = 'force-reapply';


### PR DESCRIPTION
When using patches-search containing .patch, e.g. ".patches", the directory itself will erroneusly match the files matching pattern, breaking the functionality. This patch fixes that, both on Unix/Windows by not allowing trailing (back)slashes. The fix also applies to 3.30 onwards, feel free to merge there as well. Thanks!