### PR TITLE
Support branch-alias settings in composer.json

### DIFF
--- a/src/Patch/DefinitionList/LoaderComponents/ConstraintsComponent.php
+++ b/src/Patch/DefinitionList/LoaderComponents/ConstraintsComponent.php
@@ -51,7 +51,7 @@ class ConstraintsComponent implements \Vaimo\ComposerPatches\Interfaces\Definiti
         $rootPackages = array_filter(
             $packagesByName,
             function ($package) {
-                return $package instanceof \Composer\Package\RootPackage;
+                return $package instanceof \Composer\Package\RootPackage || $package instanceof \Composer\Package\RootAliasPackage;
             }
         );
 


### PR DESCRIPTION
When the project's `composer.json` use `branch-alias`, for example:

```
        "branch-alias": {
            "dev-master": "1.5-dev"
        },
```

The root package will be instance of `RootAliasPackage` instead of `RootPackage`.

Searching for `RootPackage` will return nothing