### PR TITLE
Allow wildcard in patches search folder path

### DIFF
--- a/src/Patch/SourceLoaders/PatchesSearch.php
+++ b/src/Patch/SourceLoaders/PatchesSearch.php
@@ -102,13 +102,15 @@ class PatchesSearch implements \Vaimo\ComposerPatches\Interfaces\PatchSourceLoad
         $basePath = $this->getInstallPath($package);
         $results = array();
 
-        foreach ($source as $item) {
-            $paths = $this->fileSystemUtils->collectFilePathsRecursively(
-                $basePath . DIRECTORY_SEPARATOR . $item,
-                sprintf('/%s/i', PluginConfig::PATCH_FILE_REGEX_MATCHER)
-            );
+        foreach ($source as $sourceGlob) {
+            foreach (glob($sourceGlob) as $item) {
+                $paths = $this->fileSystemUtils->collectFilePathsRecursively(
+                    $basePath . DIRECTORY_SEPARATOR . $item,
+                    sprintf('/%s/i', PluginConfig::PATCH_FILE_REGEX_MATCHER)
+                );
 
-            $results[] = $this->createPatchDefinitions($basePath, $paths);
+                $results[] = $this->createPatchDefinitions($basePath, $paths);
+            }
         }
 
         return $results;

--- a/src/Patch/SourceLoaders/PatchesSearch.php
+++ b/src/Patch/SourceLoaders/PatchesSearch.php
@@ -102,15 +102,13 @@ class PatchesSearch implements \Vaimo\ComposerPatches\Interfaces\PatchSourceLoad
         $basePath = $this->getInstallPath($package);
         $results = array();
 
-        foreach ($source as $sourceGlob) {
-            foreach (glob($sourceGlob) as $item) {
-                $paths = $this->fileSystemUtils->collectFilePathsRecursively(
-                    $basePath . DIRECTORY_SEPARATOR . $item,
-                    sprintf('/%s/i', PluginConfig::PATCH_FILE_REGEX_MATCHER)
-                );
+        foreach ($source as $item) {
+            $paths = $this->fileSystemUtils->collectFilePathsRecursively(
+                $basePath . DIRECTORY_SEPARATOR . $item,
+                sprintf('/%s/i', PluginConfig::PATCH_FILE_REGEX_MATCHER)
+            );
 
-                $results[] = $this->createPatchDefinitions($basePath, $paths);
-            }
+            $results[] = $this->createPatchDefinitions($basePath, $paths);
         }
 
         return $results;


### PR DESCRIPTION
Closes: #75 

This PR adds the functionality to add wildcards to the path of folders to search in

Example configuration for this would be
```
    "extra": {
        "patcher": {
            "search": ["patches", "app/code/<vendor>/*/patches", "vendor/<vendor>/*/patches"]
        }
    }
```