### PR TITLE
PHP 8.1 compatibility > Always pass string to explode

### DIFF
--- a/src/Patch/SourceLoaders/PatchesSearch.php
+++ b/src/Patch/SourceLoaders/PatchesSearch.php
@@ -231,7 +231,7 @@ class PatchesSearch implements \Vaimo\ComposerPatches\Interfaces\PatchSourceLoad
         $patchTypeFlags = array_fill_keys(
             explode(
                 PatchDefinition::TYPE_SEPARATOR,
-                $this->extractSingleValue($data, PatchDefinition::TYPE)
+                (string) $this->extractSingleValue($data, PatchDefinition::TYPE)
             ),
             true
         );


### PR DESCRIPTION
Fixes this notice on PHP 8.1:
```
Deprecation Notice: explode(): Passing null to parameter #2 ($string) of type string is deprecated in vendor/vaimo/composer-patches/src/Patch/SourceLoaders/PatchesSearch.php:234
```