### PR TITLE
GJZ-3 conflict marker for cweagans/composer-patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "phpmd/phpmd": ">=2.6.0",
         "vaimo/composer-changelogs": "^0.17.0"
     },
+    "conflict": {
+        "cweagans/composer-patches": "*"
+    },
     "config": {
         "platform": {
             "php": "5.3.9"


### PR DESCRIPTION
A partial solution for #66 - both modules use `extra.patches` but with different syntax, so if one module is installed and in use, and the other gets installed, unpredictable behaviour results without clear warnings.

(note - I tried creating a unit test for this, but couldn't get any tests to run after a few hours of hacking)