### PR TITLE
Fixes PHP 8.2 deprecation notice

### DIFF
--- a/src/Patch/File/Applier.php
+++ b/src/Patch/File/Applier.php
@@ -41,6 +41,11 @@ class Applier
     private $outputAnalyser;
 
     /**
+     * @var \Vaimo\ComposerPatches\Factories\ApplierErrorFactory
+     */
+    private $applierErrorFactory;
+
+    /**
      * @var array
      */
     private $resultCache;


### PR DESCRIPTION
Following line gets outputted when executing this module with PHP 8.2:

```
Deprecation Notice: Creation of dynamic property Vaimo\ComposerPatches\Patch\File\Applier::$applierErrorFactory is deprecated in vendor/vaimo/composer-patches/src/Patch/File/Applier.php:63
```

This PR should fix that.

Fixes #104 

