### PR TITLE
Fix `loophp/phposinfo` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "composer-plugin-api": "^1.0 || ^2.0",
         "composer-runtime-api": "^1.0 || ^2.0",
-        "loophp/phposinfo": "^1.6",
+        "loophp/phposinfo": "^1.7",
         "seld/jsonlint": "^1.7.1",
         "vaimo/topological-sort": "^1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9305fa8fc0d6228532cfc03c1873014",
+    "content-hash": "38211d5c4a06789d69ef5fc8e176c6c5",
     "packages": [
         {
             "name": "loophp/phposinfo",
@@ -2294,7 +2294,8 @@
     "platform": {
         "php": ">=7.0.0",
         "ext-json": "*",
-        "composer-plugin-api": "^1.0 || ^2.0"
+        "composer-plugin-api": "^1.0 || ^2.0",
+        "composer-runtime-api": "^1.0 || ^2.0"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
It looks like the namespace in 1.6 is still the old one from drupol/phposinfo which breaks usage here. See https://github.com/phpstan/phpstan-src/pull/2304#issuecomment-1484197163

I had problems running the bootstrap composer script locally, but was hoping that my env is somehow the reason and I can still open this PR. let's see 🤞