### PR TITLE
Add JSON output format flag and correct return value in ListCommand

### DIFF
--- a/src/Composer/Commands/ListCommand.php
+++ b/src/Composer/Commands/ListCommand.php
@@ -194,6 +194,8 @@ class ListCommand extends \Composer\Command\BaseCommand
         }
 
         $this->generateOutput($output, $patches);
+        
+        return self::SUCCESS;
     }
 
     private function createUnfilteredPatchLoaderPool(\Vaimo\ComposerPatches\Composer\Context $composerContext)

--- a/src/Composer/Commands/ListCommand.php
+++ b/src/Composer/Commands/ListCommand.php
@@ -96,6 +96,13 @@ class ListCommand extends \Composer\Command\BaseCommand
             InputOption::VALUE_NONE,
             'Use latest information from package configurations in vendor folder'
         );
+
+        $this->addOption(
+            '--json',
+            null,
+            InputOption::VALUE_NONE,
+            'Output the list of patches in JSON format'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -193,8 +200,12 @@ class ListCommand extends \Composer\Command\BaseCommand
             ));
         }
 
-        $this->generateOutput($output, $patches);
-        
+        if ($input->getOption('json')) {
+            $output->writeln(json_encode($patches));
+        } else {
+            $this->generateOutput($output, $patches);
+        }
+
         return self::SUCCESS;
     }
 


### PR DESCRIPTION
To fix;

```
  [TypeError]                                                                                                                                               
  Return value of "Vaimo\ComposerPatches\Composer\Commands\ListCommand::execute()" must be of the type int, "null" returned.
```