### PR TITLE
Run test suite without asking questions

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -520,8 +520,8 @@ EOF
 
         php -r "${php_script}" 2>/dev/null
     fi
-    
-    composer install --ansi --no-plugins &>/dev/null
+
+    composer --no-interaction install --ansi --no-plugins &>/dev/null
 }
 
 sanitize() {
@@ -615,9 +615,9 @@ fi
             cp -R ${sandbox_root}/modules ${installation_root}
 
             if [ ! -f composer.lock ] ; then
-                composer install --ansi --no-plugins
+                composer --no-interaction install --ansi --no-plugins
             else
-                composer install --ansi --no-plugins &>/dev/null
+                composer --no-interaction install --ansi --no-plugins &>/dev/null
             fi
 
             cp composer.json composer.json.org
@@ -641,7 +641,7 @@ fi
                     cp composer.lock.org composer.lock
                     if [ "${cdiff}" != "" ] ; then
                         _info "RESTORING INSTALLATION"
-                        composer install --no-plugins
+                        composer --no-interaction install --no-plugins
                     fi
 
                     sanitize "${copy_target}"
@@ -654,7 +654,7 @@ fi
                     cp composer.lock.org composer.lock
                     if [ "${cdiff}" != "" ] ; then
                         _info "RESTORING INSTALLATION"
-                        composer install --no-plugins
+                        composer --no-interaction install --no-plugins
                     fi
                     
                     sanitize_scenario "${scenario_root}" "${copy_target}"

--- a/bin/test
+++ b/bin/test
@@ -394,6 +394,8 @@ apply_patches() {
     local args=${1}
     local out_file=${2}
 
+    composer --no-interaction config allow-plugins.vaimo/composer-patches-local true
+
     local command="composer --no-interaction ${args} --ansi"
 
     if [ "${VERBOSE}" == "1" ] ; then

--- a/bin/test
+++ b/bin/test
@@ -393,9 +393,9 @@ process_assertions() {
 apply_patches() {
     local args=${1}
     local out_file=${2}
- 
-    local command="composer ${args} --ansi"
- 
+
+    local command="composer --no-interaction ${args} --ansi"
+
     if [ "${VERBOSE}" == "1" ] ; then
         command="${command} -vvv"
     fi


### PR DESCRIPTION
I'm working on fixing a bug in this package, and I want to make sure that the test suite runs properly both before & after the proposed change (pull request coming for that separately). When I ran the test suite initially, I was asked several times to allow the plug-in `vaimo/composer-patches-local`. If I chose to decline this request, the test suite failed. This pull request marks the plug-in as trusted and tells Composer to not ask questions.

This is my first pull request for this project. I've not yet managed to run the test-suite locally in full / successfully, so I'm unsure if this will break existing behaviour. I trust that the automated tests here will highlight any potential issues.