### PR TITLE
Only process versions as a version constraint

### DIFF
--- a/src/Patch/Definition/ExploderComponents/LabelVersionConfigComponent.php
+++ b/src/Patch/Definition/ExploderComponents/LabelVersionConfigComponent.php
@@ -21,6 +21,10 @@ class LabelVersionConfigComponent implements \Vaimo\ComposerPatches\Interfaces\D
 
     public function shouldProcess($label, $data)
     {
+        if ($label !== PatchDefinition::VERSION) {
+            return false;
+        }
+
         if (!is_array($data)) {
             return $this->valueAnalyser->isConstraint($data);
         }


### PR DESCRIPTION
When a patch is defined with a `level` and a `source`, the order of these is important but shouldn't be. When the `source` is defined first, then the patch is applied. However, when the `level` is defined first, then the patch is not applied. This seems to be related to the `LabelVersionConfigComponent` class interpreting the first item in the data array as a constraint. As the value is a number, this passes the "is this a version constraint" test, but because that version constraint doesn't match the installed version of the package, the patch is not applied.

<details><summary>Full <code>composer.json</code> showing problem</summary>

```json
{
    "type": "project",
    "require": {
        "php": "~8.2.0",
        "magento/magento-coding-standard": "*",
        "vaimo/composer-patches": "^5.1"
    },
    "config": {
        "allow-plugins": {
            "dealerdirect/phpcodesniffer-composer-installer": true,
            "vaimo/composer-patches": true
        }
    },
    "extra": {
        "patches": {
            "magento/magento-coding-standard": {
                "$block->escape... versus $escaper->escape...": {
                    "level": "1",
                    "source": "https://github.com/magento/magento-coding-standard/pull/458.diff"
                }
            }
        }
    }
}
```

</details>

This is my first real pull request for this project. I've not been able to successfully run the test-suite locally. Please can I have some help creating a test for this problem. I'm not confident that this change is the correct way to fix this bug, nor that there are no knock-on effects. I'm hoping that the test-suite runs as expected here, and that I can adjust this pull request based on the results reported, however running the test-suite locally would be best.