### PR TITLE
Fix PHP 8.4 deprecation notices

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -64,8 +64,8 @@ class Bootstrap
         \Vaimo\ComposerPatches\Composer\Context $composerContext,
         \Composer\IO\IOInterface $appIO,
         \Vaimo\ComposerPatches\Factories\ConfigFactory $configFactory,
-        \Vaimo\ComposerPatches\Interfaces\ListResolverInterface $listResolver = null,
-        \Vaimo\ComposerPatches\Strategies\OutputStrategy $outputStrategy = null
+        ?\Vaimo\ComposerPatches\Interfaces\ListResolverInterface $listResolver = null,
+        ?\Vaimo\ComposerPatches\Strategies\OutputStrategy $outputStrategy = null
     ) {
         $this->composerContext = $composerContext;
         $this->listResolver = $listResolver;

--- a/src/Exceptions/PatchFailureException.php
+++ b/src/Exceptions/PatchFailureException.php
@@ -12,7 +12,7 @@ class PatchFailureException extends \Exception
      */
     private $failedPatchPath;
 
-    public function __construct($failedPatchPath, $message = '', \Exception $previous = null)
+    public function __construct($failedPatchPath, $message = '', ?\Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
 

--- a/src/Factories/BootstrapFactory.php
+++ b/src/Factories/BootstrapFactory.php
@@ -36,8 +36,8 @@ class BootstrapFactory
 
     public function create(
         ConfigFactory $configFactory,
-        ListResolver $listResolver = null,
-        OutputStrategy $outputStrategy = null
+        ?ListResolver $listResolver = null,
+        ?OutputStrategy $outputStrategy = null
     ) {
         if ($listResolver === null) {
             $listResolver = new ListResolvers\ChangesListResolver(


### PR DESCRIPTION
Fixes https://github.com/vaimo/composer-patches/issues/117 by correcting the deprecation notices.