### PR TITLE
Only rewrite lockfile if the data has changed

### DIFF
--- a/src/Repository/Lock/Sanitizer.php
+++ b/src/Repository/Lock/Sanitizer.php
@@ -40,6 +40,8 @@ class Sanitizer
             return;
         }
 
+        $dataChanged = false;
+
         $queriedPaths = array(
             implode('/', array(Config::PACKAGES, Constraint::ANY)),
             implode('/', array(Config::PACKAGES_DEV, Constraint::ANY))
@@ -53,6 +55,7 @@ class Sanitizer
             }
 
             unset($node[Config::CONFIG_ROOT][PluginConfig::APPLIED_FLAG]);
+            $dataChanged = true;
 
             if ($node[Config::CONFIG_ROOT]) {
                 continue;
@@ -63,6 +66,8 @@ class Sanitizer
 
         unset($node);
 
-        $this->lockerManager->writeLockData($lockData);
+        if ($dataChanged) {
+            $this->lockerManager->writeLockData($lockData);
+        }
     }
 }


### PR DESCRIPTION
This both improves performance by reducing the number of times that the disk gets written to, and also should fix the bug where the data-type gets changed mistakenly by this plug-in on Composer v2.8.2 or later.

In my testing this fixes the bug described in #120. (I'm carefully not using the closing keyword though, so that this can be verified properly.) I still haven't been able to get the test suite working for this plug-in.