### PR TITLE
Feature/lock data type changes continued

### DIFF
--- a/src/Repository/Lock/Sanitizer.php
+++ b/src/Repository/Lock/Sanitizer.php
@@ -66,8 +66,35 @@ class Sanitizer
 
         unset($node);
 
-        if ($dataChanged) {
-            $this->lockerManager->writeLockData($lockData);
+        if (!$dataChanged) {
+            return;
         }
+
+        $lockData = $this->fixupJsonDataType($lockData);
+        $this->lockerManager->writeLockData($lockData);
+    }
+
+    /**
+     * Copy-paste from composer/composer/src/Composer/Package/Locker.php. Would prefer to use the locker directly,
+     * but there's no alternative to src/Managers/LockerManager::writeLockData(). The method setLockData() is really
+     * close, but it seems to expect some of the data to be objects, which we don't have in this context.
+     *
+     * @param mixed[] $lockData
+     *
+     * @return mixed[]
+     */
+    private function fixupJsonDataType(array $lockData)
+    {
+        foreach (['stability-flags', 'platform', 'platform-dev'] as $key) {
+            if (isset($lockData[$key]) && is_array($lockData[$key]) && \count($lockData[$key]) === 0) {
+                $lockData[$key] = new \stdClass();
+            }
+        }
+
+        if (is_array($lockData['stability-flags'])) {
+            ksort($lockData['stability-flags']);
+        }
+
+        return $lockData;
     }
 }


### PR DESCRIPTION
Relates to https://github.com/vaimo/composer-patches/issues/120

Refined the solution from https://github.com/vaimo/composer-patches/pull/123 further by implementing the data type fix from Composer itself in `src/Repository/Lock/Sanitizer`, which should ensure the data types remain consistent in `composer.lock` even if the Sanitizer does need to do changes