### PR TITLE
Add negated dependency support

### DIFF
--- a/docs/USAGE_BASIC.md
+++ b/docs/USAGE_BASIC.md
@@ -150,7 +150,7 @@ to the user when patch is being applied.
 @label <value> (optional) overrides the description above when provided. Otherwise above info used
 @ticket <value> (optional) reference to some issue ID that relates to this fix (added to label)
 @link <value> (optional) url to additional data about this patch (added to label)
-@depends <value> (optional) other/package (make version constraint target another package instead) 
+@depends <value> (optional) other/package (make version constraint target another package instead). Use !other/package to apply patch only when package is NOT installed 
 @version <value> (optional) >=1.1.0 <1.4.0
 @after <value> (optional) Used in case a patch should be applied after another branch
 @before <value> (optional) Used in case a patch should be applied before another branch
@@ -231,6 +231,12 @@ apply correctly.
           "depends": {
             "other/package": ">=2.1.7",
             "php": ">=7.1.0"
+          }
+        },
+        "applies when unwanted/package is NOT installed": {
+          "source": "example/negated-dependency.patch",
+          "depends": {
+            "!unwanted/package": ">=1.0.0"
           }
         }
       }

--- a/src/Patch/Definition/NormalizerComponents/DependencyComponent.php
+++ b/src/Patch/Definition/NormalizerComponents/DependencyComponent.php
@@ -46,6 +46,9 @@ class DependencyComponent implements \Vaimo\ComposerPatches\Interfaces\Definitio
             );
         }
 
+        // Handle negated dependencies in JSON config
+        $depends = $this->processNegatedDependencies($depends);
+
         return array(
             PatchDefinition::DEPENDS => $depends
         );
@@ -83,5 +86,22 @@ class DependencyComponent implements \Vaimo\ComposerPatches\Interfaces\Definitio
         }
 
         return $patternValues;
+    }
+
+    private function processNegatedDependencies(array $depends)
+    {
+        $processedDepends = array();
+
+        foreach ($depends as $packageName => $version) {
+            // Handle negated dependencies with ! prefix in JSON config
+            if (strpos($packageName, '!') === 0) {
+                $packageName = substr($packageName, 1);
+                $version = array('version' => $version, 'negated' => true);
+            }
+
+            $processedDepends[$packageName] = $version;
+        }
+
+        return $processedDepends;
     }
 }

--- a/src/Patch/SourceLoaders/PatchesSearch.php
+++ b/src/Patch/SourceLoaders/PatchesSearch.php
@@ -269,9 +269,17 @@ class PatchesSearch implements \Vaimo\ComposerPatches\Interfaces\PatchSourceLoad
         $dependsNormalized = array_map(
             function ($item) {
                 $valueParts = explode(':', $item);
+                $packageName = trim(array_shift($valueParts) ?? '');
+                $version = trim(array_shift($valueParts) ?? '') ?: '>=0.0.0';
+
+                // Handle negated dependencies with ! prefix
+                if (strpos($packageName, '!') === 0) {
+                    $packageName = substr($packageName, 1);
+                    $version = array('version' => $version, 'negated' => true);
+                }
 
                 return array(
-                    trim(array_shift($valueParts) ?? '') => trim(array_shift($valueParts) ?? '') ?: '>=0.0.0'
+                    $packageName => $version
                 );
             },
             array_unique($dependsList)


### PR DESCRIPTION
Currently, you can specify a patch to apply when a specific composer package is installed using the `@depends` metadata in a patch file:

```
@depends magento/module-base:2.4.7
```

However, you cannot do the reverse of this, apply a patch if another package isn't present. 

This PR adds support for this feature, with the following syntax:

```
@depends !magento/module-base # patch when magento/module-base is not installed
@depends !magento/module-base:>=2.4.7-p6 # patch when magento/module-base is not >=2.4.7-p6
```

A use case I have is that there is code added to a package, which depends on another that we do not want to use. Subsequently, we use a composer to remove it, however, we also need to patch the module which depends on it to remove any code referencing it.