### PR TITLE
Dropping Composer 1 from Github workflows setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,16 @@ jobs:
     strategy:
       matrix:
         versions: [
-          { php: "7.0.33", composer: 1.10.27 },
-          { php: "7.1", composer: 1.10.27 },
-          { php: "7.2", composer: 1.10.27 },
-          { php: "7.3", composer: 2.2.25 },
+          { php: "7.0.33", composer: 2.2.26 },
+          { php: "7.1", composer: 2.2.26 },
+          { php: "7.2", composer: 2.2.26 },
+          { php: "7.3", composer: 2.2.26 },
           { php: "7.4", composer: 2.3.10 },
           { php: "8.0", composer: 2.3.10 },
           { php: "8.1", composer: 2.3.10 },
           { php: "8.2", composer: 2.7.7 },
           { php: "8.3", composer: 2.7.7 },
-          { php: "8.4", composer: 2.8.9 }
+          { php: "8.4", composer: 2.9.4 }
         ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Relates to https://github.com/vaimo/composer-patches/issues/140

Updated Github workflows to not use Composer 1, since this hasn't been working for a while. Composer 1 support otherwise not touched, we just won't be able to confirm if any future changes still actually work with it. 

Replaced also Composer 2.8 usage with 2.9 due to recent recommendations, but didn't touch the <2.8 versions for now to have wider test coverage for different versions.