### PR TITLE
Feature/Composer 2.10 (release/5)

### DIFF
--- a/.config/phpcs/whitelist/symfony-console/version-v8.1.0
+++ b/.config/phpcs/whitelist/symfony-console/version-v8.1.0
@@ -1,0 +1,8 @@
+Incorrect error: Helper/ProgressBar.php,457,38,PHPCompatibility.Variables.ForbiddenThisUseContexts.Unset
+Incorrect error: Helper/ProgressBar.php,496,38,PHPCompatibility.Variables.ForbiddenThisUseContexts.Unset
+Incorrect error: Output/AnsiColorMode.php,63,23,PHPCompatibility.Variables.ForbiddenThisUseContexts.OutsideObjectContext
+Incorrect error: Output/AnsiColorMode.php,64,37,PHPCompatibility.Variables.ForbiddenThisUseContexts.OutsideObjectContext
+Incorrect error: Output/AnsiColorMode.php,65,35,PHPCompatibility.Variables.ForbiddenThisUseContexts.OutsideObjectContext
+Incorrect error: Output/AnsiColorMode.php,72,23,PHPCompatibility.Variables.ForbiddenThisUseContexts.OutsideObjectContext
+Incorrect error: Output/AnsiColorMode.php,73,28,PHPCompatibility.Variables.ForbiddenThisUseContexts.OutsideObjectContext
+Incorrect error: Output/AnsiColorMode.php,74,28,PHPCompatibility.Variables.ForbiddenThisUseContexts.OutsideObjectContext

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           { php: "8.2.31", composer: 2.9.8 },
           { php: "8.3.31", composer: 2.9.8 },
           { php: "8.4.21", composer: 2.9.8 },
-          { php: "8.5.6", composer: 2.9.8 }
+          { php: "8.5.6", composer: 2.10.0 }
         ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Following changes done towards `release/5` branch:

- Updated workflows to check for Composer 2.10
- Updated dependency check whitelists to include `symfony/console` 8
- No changes necessary for Composer 2.10 in the application code