### PR TITLE
Feature/applicable variable in patch list

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -4,6 +4,11 @@
         "possible to generate change-logs in other formats as well (when needed) and to do automatic releases based on",
         "added change-log records. More on how to use it: https://github.com/vaimo/composer-changelogs"
     ],
+    "6.0.3": {
+        "maintenance": [
+            "Added an 'applicable' flag to 'patch:list' output, distinguishing patches excluded due to version/platform constraint mismatches from patches excluded for other reasons (skip, exclude config, local/root-patch scoping)"
+        ]
+    },
     "6.0.1": {
         "maintenance": [
             "Updated dev dependency to vaimo/composer-changelogs to allow installing version with equal PHP version support as in version 6 of the patcher: https://github.com/vaimo/composer-patches/pull/147",

--- a/src/Composer/Commands/ListCommand.php
+++ b/src/Composer/Commands/ListCommand.php
@@ -183,15 +183,30 @@ class ListCommand extends \Composer\Command\BaseCommand
 
             $patchesQueue = $listResolver->resolvePatchesQueue($allPatches);
 
-            $excludedPatches = $patchListUpdater->updateStatuses(
-                array_filter($patchListUtils->diffListsByPath($patchesQueue, $filteredPatches)),
-                'excluded'
+            $excludedPatches = array_filter($patchListUtils->diffListsByPath($patchesQueue, $filteredPatches));
+
+            $constraintCheckedPool = $this->createConstraintCheckedPatchLoaderPool($composerContext);
+            $constraintCheckedLoader = $loaderFactory->create($constraintCheckedPool, $pluginConfig, $isDevMode);
+
+            $constraintValidPatches = $listResolver->resolvePatchesQueue(
+                $constraintCheckedLoader->loadFromPackagesRepository($repository)
             );
 
-            $patches = array_replace_recursive(
-                $patches,
-                $patchListUpdater->updateStatuses($excludedPatches, 'excluded')
+            $excludedPatches = $patchListUpdater->embedInfoToItems($excludedPatches, array(
+                Patch::APPLICABLE => false
+            ));
+
+            $excludedPatches = array_replace_recursive(
+                $excludedPatches,
+                $patchListUpdater->embedInfoToItems(
+                    $patchListUtils->intersectListsByPath($excludedPatches, $constraintValidPatches),
+                    array(Patch::APPLICABLE => true)
+                )
             );
+
+            $excludedPatches = $patchListUpdater->updateStatuses($excludedPatches, 'excluded');
+
+            $patches = array_replace_recursive($patches, $excludedPatches);
 
             array_walk($patches, function (array &$group) {
                 ksort($group);
@@ -218,12 +233,7 @@ class ListCommand extends \Composer\Command\BaseCommand
 
     private function createUnfilteredPatchLoaderPool(\Vaimo\ComposerPatches\Composer\Context $composerContext)
     {
-        $composer = $composerContext->getLocalComposer();
-
-        $packageInfoResolver = new \Vaimo\ComposerPatches\Package\InfoResolver(
-            $composer->getInstallationManager(),
-            $composer->getConfig()->get(\Vaimo\ComposerPatches\Composer\ConfigKeys::VENDOR_DIR)
-        );
+        $packageInfoResolver = $this->createPackageInfoResolver($composerContext);
 
         $componentOverrides =  array(
             'constraints' => false,
@@ -235,6 +245,30 @@ class ListCommand extends \Composer\Command\BaseCommand
         );
 
         return $this->createLoaderPool($composerContext, $componentOverrides);
+    }
+
+    private function createConstraintCheckedPatchLoaderPool(\Vaimo\ComposerPatches\Composer\Context $composerContext)
+    {
+        $packageInfoResolver = $this->createPackageInfoResolver($composerContext);
+
+        $componentOverrides = array(
+            'local-exclude' => false,
+            'root-patch' => false,
+            'global-exclude' => false,
+            'targets-resolver' => new LoaderComponents\TargetsResolverComponent($packageInfoResolver, true)
+        );
+
+        return $this->createLoaderPool($composerContext, $componentOverrides);
+    }
+
+    private function createPackageInfoResolver(\Vaimo\ComposerPatches\Composer\Context $composerContext)
+    {
+        $composer = $composerContext->getLocalComposer();
+
+        return new \Vaimo\ComposerPatches\Package\InfoResolver(
+            $composer->getInstallationManager(),
+            $composer->getConfig()->get(\Vaimo\ComposerPatches\Composer\ConfigKeys::VENDOR_DIR)
+        );
     }
 
     private function composerFilteredPatchesList($patches, $additions, $removals, $withAffected, $filters, $statuses)

--- a/src/Patch/Definition.php
+++ b/src/Patch/Definition.php
@@ -29,6 +29,7 @@ class Definition
     const SKIP = 'skip';
     const LOCAL = 'local';
     const CATEGORY = 'category';
+    const APPLICABLE = 'applicable';
 
     const CWD = 'cwd';
     const CWD_INSTALL = 'install';

--- a/src/Patch/Definition/NormalizerComponents/DefaultValuesComponent.php
+++ b/src/Patch/Definition/NormalizerComponents/DefaultValuesComponent.php
@@ -19,7 +19,8 @@ class DefaultValuesComponent implements \Vaimo\ComposerPatches\Interfaces\Defini
             PatchDefinition::STATUS_CHANGED => true,
             PatchDefinition::STATUS_MATCH => false,
             PatchDefinition::STATUS_LABEL => '',
-            PatchDefinition::CHECKSUM => ''
+            PatchDefinition::CHECKSUM => '',
+            PatchDefinition::APPLICABLE => true
         );
     }
 }


### PR DESCRIPTION
## Add `applicable` field to `patch:list` JSON output

### Problem

`composer patch:list --with-excludes --json` lumps every non-applied patch into a single `"state": "excluded"` bucket, with no way to tell *why* it was excluded. In practice there are two very different reasons:

1. The patch genuinely can't apply here — its version/platform constraint doesn't match, or its target package isn't even installed in this project.
2. The patch *would* apply fine, but something else turned it off — a `skip` flag, a `patches-exclude` entry, or local/root-patch scoping.

Both currently look identical in the output, so there's no way to distinguish "this patch is irrelevant to this project" from "this patch was deliberately disabled."

### What `applicable` means

A new boolean field, present on every patch in `patch:list --json` output:

- **`applicable: true`**
  - The patch is applied (or `new`/`changed`/`removed` — i.e. it's live in the main list), **or**
  - it's excluded, but its version/platform constraints and target package would otherwise be satisfied — something else (skip flag, exclude config, local/root-patch scoping) is what's keeping it out.
- **`applicable: false`**
  - The patch fails its version/platform constraints, or targets a package that isn't installed in this project at all.

In short: `applicable` answers "does this patch even belong to this project's dependency set?", independently of whether it's currently turned on or off for other reasons.

### Example

```json
{
    "state": "excluded",
    "applicable": false,
    "depends": { "magento/magento2-base": ">=2.1.0 <2.1.17" }
}
```
vs.
```json
{
    "state": "excluded",
    "applicable": true,
    "depends": { "magento/module-widget": ">=101.0.0" }
}
```
The first fails its version constraint against the installed package. The second's constraint is satisfied, but it's excluded for some other reason.

### Implementation

- `Patch\Definition::APPLICABLE` constant added; defaults to `true` in `DefaultValuesComponent` (covers the applied/new/changed/removed case automatically).
- `ListCommand` gains a third loader pool (`createConstraintCheckedPatchLoaderPool`) alongside the existing normal and unfiltered pools — it disables only the non-constraint exclusion components (`local-exclude`, `root-patch`, `global-exclude`) while keeping `constraints`/`platform` active.
- Any patch in the `excluded` bucket that also appears in that pool's output gets `applicable: true`; everything else stays `applicable: false`. Uses the existing `PatchListUtils::intersectListsByPath()`/`diffListsByPath()` helpers — no new list-diffing logic needed.
- No changes to the plain-text output — `applicable` is JSON-only, same as `match`/`new`/`changed`.
### Backports for releases 3,4,5:
- https://github.com/vaimo/composer-patches/pull/164
- https://github.com/vaimo/composer-patches/pull/165
- https://github.com/vaimo/composer-patches/pull/168