### PR TITLE
Feature/applicable variable in patch list release3

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -4,6 +4,15 @@
         "possible to generate change-logs in other formats as well (when needed) and to do automatic releases based on",
         "added change-log records. More on how to use it: https://github.com/vaimo/composer-changelogs"
     ],
+    "3.53.5": {
+        "feature": [
+            "Backported '--json' output flag for 'patch:list' from later releases"
+        ],
+        "maintenance": [
+            "Added an 'applicable' flag to 'patch:list' JSON output, distinguishing patches excluded due to version/platform constraint mismatches from patches excluded for other reasons (skip, exclude config, local/root-patch scoping, legacy custom-exclude env vars)"
+        ],
+        "branch": "release/3"
+    },
     "3.53.4": {
         "fix": [
             "bundled patches fail to apply when using patch-mapping configuration due to refactored code in 3.53.2 having messed up argument order used for a sub-function call in BasePathComponent"

--- a/src/Composer/Commands/ListCommand.php
+++ b/src/Composer/Commands/ListCommand.php
@@ -94,6 +94,13 @@ class ListCommand extends \Composer\Command\BaseCommand
             InputOption::VALUE_NONE,
             'Use latest information from package configurations in vendor folder'
         );
+
+        $this->addOption(
+            '--json',
+            null,
+            InputOption::VALUE_NONE,
+            'Output the list of patches in JSON format'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -191,7 +198,15 @@ class ListCommand extends \Composer\Command\BaseCommand
             ));
         }
 
+        if ($input->getOption('json')) {
+            $output->writeln(json_encode($patches));
+
+            return 0;
+        }
+
         $this->generateOutput($output, $patches);
+
+        return 0;
     }
 
     private function createUnfilteredPatchLoaderPool(\Vaimo\ComposerPatches\Composer\Context $composerContext)

--- a/src/Composer/Commands/ListCommand.php
+++ b/src/Composer/Commands/ListCommand.php
@@ -248,6 +248,7 @@ class ListCommand extends \Composer\Command\BaseCommand
             'local-exclude' => false,
             'root-patch' => false,
             'global-exclude' => false,
+            'custom-exclude' => false,
             'targets-resolver' => new LoaderComponents\TargetsResolverComponent($packageInfoResolver, true)
         );
 

--- a/src/Composer/Commands/ListCommand.php
+++ b/src/Composer/Commands/ListCommand.php
@@ -176,15 +176,30 @@ class ListCommand extends \Composer\Command\BaseCommand
 
             $patchesQueue = $listResolver->resolvePatchesQueue($allPatches);
 
-            $excludedPatches = $patchListUpdater->updateStatuses(
-                array_filter($patchListUtils->diffListsByPath($patchesQueue, $filteredPatches)),
-                'excluded'
+            $excludedPatches = array_filter($patchListUtils->diffListsByPath($patchesQueue, $filteredPatches));
+
+            $constraintCheckedPool = $this->createConstraintCheckedPatchLoaderPool($composerContext);
+            $constraintCheckedLoader = $loaderFactory->create($constraintCheckedPool, $pluginConfig, $isDevMode);
+
+            $constraintValidPatches = $listResolver->resolvePatchesQueue(
+                $constraintCheckedLoader->loadFromPackagesRepository($repository)
             );
 
-            $patches = array_replace_recursive(
-                $patches,
-                $patchListUpdater->updateStatuses($excludedPatches, 'excluded')
+            $excludedPatches = $patchListUpdater->embedInfoToItems($excludedPatches, array(
+                Patch::APPLICABLE => false
+            ));
+
+            $excludedPatches = array_replace_recursive(
+                $excludedPatches,
+                $patchListUpdater->embedInfoToItems(
+                    $patchListUtils->intersectListsByPath($excludedPatches, $constraintValidPatches),
+                    array(Patch::APPLICABLE => true)
+                )
             );
+
+            $excludedPatches = $patchListUpdater->updateStatuses($excludedPatches, 'excluded');
+
+            $patches = array_replace_recursive($patches, $excludedPatches);
 
             array_walk($patches, function (array &$group) {
                 ksort($group);
@@ -211,12 +226,7 @@ class ListCommand extends \Composer\Command\BaseCommand
 
     private function createUnfilteredPatchLoaderPool(\Vaimo\ComposerPatches\Composer\Context $composerContext)
     {
-        $composer = $composerContext->getLocalComposer();
-
-        $packageInfoResolver = new \Vaimo\ComposerPatches\Package\InfoResolver(
-            $composer->getInstallationManager(),
-            $composer->getConfig()->get(\Vaimo\ComposerPatches\Composer\ConfigKeys::VENDOR_DIR)
-        );
+        $packageInfoResolver = $this->createPackageInfoResolver($composerContext);
 
         $componentOverrides =  array(
             'constraints' => false,
@@ -228,6 +238,30 @@ class ListCommand extends \Composer\Command\BaseCommand
         );
 
         return $this->createLoaderPool($composerContext, $componentOverrides);
+    }
+
+    private function createConstraintCheckedPatchLoaderPool(\Vaimo\ComposerPatches\Composer\Context $composerContext)
+    {
+        $packageInfoResolver = $this->createPackageInfoResolver($composerContext);
+
+        $componentOverrides = array(
+            'local-exclude' => false,
+            'root-patch' => false,
+            'global-exclude' => false,
+            'targets-resolver' => new LoaderComponents\TargetsResolverComponent($packageInfoResolver, true)
+        );
+
+        return $this->createLoaderPool($composerContext, $componentOverrides);
+    }
+
+    private function createPackageInfoResolver(\Vaimo\ComposerPatches\Composer\Context $composerContext)
+    {
+        $composer = $composerContext->getLocalComposer();
+
+        return new \Vaimo\ComposerPatches\Package\InfoResolver(
+            $composer->getInstallationManager(),
+            $composer->getConfig()->get(\Vaimo\ComposerPatches\Composer\ConfigKeys::VENDOR_DIR)
+        );
     }
 
     private function composerFilteredPatchesList($patches, $additions, $removals, $withAffected, $filters, $statuses)

--- a/src/Patch/Definition.php
+++ b/src/Patch/Definition.php
@@ -29,6 +29,7 @@ class Definition
     const SKIP = 'skip';
     const LOCAL = 'local';
     const CATEGORY = 'category';
+    const APPLICABLE = 'applicable';
 
     const CWD = 'cwd';
     const CWD_INSTALL = 'install';

--- a/src/Patch/Definition/NormalizerComponents/DefaultValuesComponent.php
+++ b/src/Patch/Definition/NormalizerComponents/DefaultValuesComponent.php
@@ -19,7 +19,8 @@ class DefaultValuesComponent implements \Vaimo\ComposerPatches\Interfaces\Defini
             PatchDefinition::STATUS_CHANGED => true,
             PatchDefinition::STATUS_MATCH => false,
             PatchDefinition::STATUS_LABEL => '',
-            PatchDefinition::CHECKSUM => ''
+            PatchDefinition::CHECKSUM => '',
+            PatchDefinition::APPLICABLE => true
         );
     }
 }


### PR DESCRIPTION
The backport of https://github.com/vaimo/composer-patches/pull/163 for release/3.
Not tested yet.